### PR TITLE
Added completed_bps metric to existing guidestar metrics

### DIFF
--- a/gatherer.py
+++ b/gatherer.py
@@ -123,12 +123,12 @@ def catalog(gl_codes, metrics={}):
                 metrics['subject_{}'.format(y['subject'])] =0
             metrics['subject_{}'.format(y['subject'])] +=1
     metrics['all_resources'] = all_resources
-    isTa = False
-    isTn = False
-    isTq = False
-    isTw = False    
     counts = {}
     for lang in catalog['languages']:                # look at all the languages
+        isTa = False
+        isTn = False
+        isTq = False
+        isTw = False    
         lc = lang['identifier']
         for res in lang['resources']:
             resource = res['identifier']
@@ -153,10 +153,6 @@ def catalog(gl_codes, metrics={}):
                 if key.find(lc) == 0:
                     if counts[key] > 0:        
                         all_bpfs += 1    
-        isTa = False
-        isTn = False
-        isTq = False
-        isTw = False    
     metrics['completed_bps'] = all_bpfs
     logger.info(metrics)
     return metrics

--- a/gatherer.py
+++ b/gatherer.py
@@ -108,7 +108,8 @@ def getAlignmentCounts(lc, cdnPath):
                         count = theText.count('\\zaln-s')
                         if count > 0:
                             counts[slug] = count
-                            #logger.info(' getAlignmentCounts: filename: ' + filename + ' counts[' + slug + ']: ' + str(counts[slug]))
+                            #if count < 300:
+                            #    logger.info(' getAlignmentCounts: filename: ' + filename + ' counts[' + slug + ']: ' + str(counts[slug]))
     return counts
 
 def catalog(gl_codes, metrics={}):
@@ -165,20 +166,20 @@ def catalog(gl_codes, metrics={}):
         # end of language
         if isTa and isTn and isTq and isTw:   
             #previousBpfs = all_bpfs
-            #logger.info(' catalog: got all resources for: ' + lc)   
+            #logger.info(' catalog: got all resources for: ' + lc + '_' + resource)   
             for key in counts:
                 if key.find(lc) == 0:
                     #logger.info(' catalog: key: ' + key)
                     if counts[key] > 0:        
                         all_bpfs += 1    
                         #logger.info(' catalog: Found BP for: ' + key)  
-            #logger.info( ' catalog added: ' + str(all_bpfs - previousBpfs) + ' BPs')
+            #logger.info( ' catalog: added: ' + str(all_bpfs - previousBpfs) + ' BPs from: ' + key)
         isTa = False
         isTn = False
         isTq = False
         isTw = False    
-    logger.info( ' catalog: Elapsed time: ' + str(time.time() - startTime) + ' seconds')                                               
-    metrics['all_bpfs'] = all_bpfs
+    #logger.info( ' catalog: Elapsed time: ' + str(time.time() - startTime) + ' seconds')                                               
+    metrics['completed_bps'] = all_bpfs
     logger.info(metrics)
     return metrics
 

--- a/gatherer.py
+++ b/gatherer.py
@@ -8,8 +8,6 @@ import statsd
 import logging
 import requests
 import datetime
-import urllib.request
-import time
 import io
 import requests
 import zipfile
@@ -43,13 +41,13 @@ dsm_board_pos = { 'G0WhbXlL': 'one',
                   'B7SE15xE': 'seven'
                 }
 milestones_api = "https://api.github.com/repos/unfoldingWord-dev/translationCore/milestones"
-issues_api     = "https://api.github.com/repos/unfoldingWord-dev/translationCore/issues?milestone={0}"
-tasks_api      = "https://api.github.com/repos/unfoldingWord-dev/translationCore/issues?labels=Task&page={0}"
-zenhub_api     = "https://api.zenhub.io/p1/repositories/65028237/board?access_token={0}"
-sendgrid_api   = "https://api.sendgrid.com/v3/stats?start_date={0}"
-d43api_api     = "https://api.door43.org/v3/lambda/status"
-trello_api     = "https://api.trello.com/1/boards/{0}"
-catalog_api    = "https://api.door43.org/v3/catalog.json"
+issues_api = "https://api.github.com/repos/unfoldingWord-dev/translationCore/issues?milestone={0}"
+tasks_api = "https://api.github.com/repos/unfoldingWord-dev/translationCore/issues?labels=Task&page={0}"
+zenhub_api = "https://api.zenhub.io/p1/repositories/65028237/board?access_token={0}"
+sendgrid_api = "https://api.sendgrid.com/v3/stats?start_date={0}"
+d43api_api = "https://api.door43.org/v3/lambda/status"
+trello_api = "https://api.trello.com/1/boards/{0}"
+catalog_api = "https://api.door43.org/v3/catalog.json"
 
 def get_env_var(env_name):
     env_variable = os.getenv(env_name, False)
@@ -217,9 +215,6 @@ def getAvailableHours(multiplier, metrics={}):
 
 def getMilestoneTimeLeft():
     milestone_json = getJSONfromURL(milestones_api, github_token)
-    pp = pprint.PrettyPrinter()
-    print('      milestone_json: ')
-    pp.pprint(milestone_json)
     endDate = milestone_json[0]['due_on']
     y, m, d = [int(x) for x in endDate.split('T')[0].split('-')]
     return datetime.datetime(y, m, d) - datetime.datetime.today()
@@ -388,9 +383,3 @@ if __name__ == "__main__":
         directory = 'okrs/{0}'.format(col.replace(' ', '_').replace('+', '_'))
         trelloUpload(html, directory)
 
-# Retired tests
-#import pprint  # dump an object, test only.
-#pp = pprint.PrettyPrinter()
-#print('       ' + lc + ': ')
-#pp.pprint(counts)
-#myPrint('counts', counts)


### PR DESCRIPTION
For each aligned bible, new code opens the language zip file and counts the number of books that contain any "\zaln-s" tags indicating start of alignment. It then verifies that there are all of tA, tN, tQ, and tW resources in the catalog

Number of completed_bps detected at build time was 132

To Test:
Verify that docker container is automatically deployed.
Verify that dashboard displayed number for completed_bps is near what was generated during build.